### PR TITLE
Add argument db to the convertFilter signature

### DIFF
--- a/R/AllGenerics.R
+++ b/R/AllGenerics.R
@@ -11,7 +11,7 @@ setGeneric("not", function(object, ...) standardGeneric("not"))
 
 setGeneric("simplify", function(object, ...) standardGeneric("simplify"))
 
-setGeneric("convertFilter", function(object, ...)
+setGeneric("convertFilter", function(object, db, ...)
     standardGeneric("convertFilter"))
 
 setGeneric("distributeNegation", function(object, ...)

--- a/R/AnnotationFilter.R
+++ b/R/AnnotationFilter.R
@@ -489,14 +489,15 @@ local({
 #'      a \code{dplyr} filter.
 #'
 #' @return \code{character(1)} that can be used as input to a \code{dplyr} 
-#'      fitlter.
+#'      filter.
 #'
 #' @examples
 #' filter <- SymbolFilter("ADA", "==")
 #' result <- convertFilter(filter)
 #' result
 #' @export
-setMethod("convertFilter", "AnnotationFilter", .convertFilter)
+setMethod("convertFilter", signature(object = "AnnotationFilter",
+                                     db = "missing"), .convertFilter)
 
 .FILTERS_WO_FIELD <- c("GRangesFilter")
 

--- a/man/AnnotationFilter.Rd
+++ b/man/AnnotationFilter.Rd
@@ -69,7 +69,7 @@
 \alias{GRangesFilter}
 \alias{feature}
 \alias{AnnotationFilter}
-\alias{convertFilter,AnnotationFilter-method}
+\alias{convertFilter,AnnotationFilter,missing-method}
 \alias{supportedFilters,missing-method}
 \alias{AnnotationFilter}
 \title{Filters for annotation objects}
@@ -111,7 +111,7 @@ GRangesFilter(value, feature = "gene", type = c("any", "start", "end",
 
 feature(object)
 
-\S4method{convertFilter}{AnnotationFilter}(object)
+\S4method{convertFilter}{AnnotationFilter,missing}(object)
 
 \S4method{supportedFilters}{missing}(object)
 
@@ -152,7 +152,7 @@ The constructor function return an object extending
     the methods' descriptions.
 
 \code{character(1)} that can be used as input to a \code{dplyr} 
-     fitlter.
+     filter.
 
 \code{AnnotationFilter} returns an
     \code{\link{AnnotationFilter}} or an \code{\link{AnnotationFilterList}}.

--- a/man/AnnotationFilterList.Rd
+++ b/man/AnnotationFilterList.Rd
@@ -12,7 +12,7 @@
 \alias{not}
 \alias{distributeNegation,AnnotationFilterList-method}
 \alias{distributeNegation}
-\alias{convertFilter,AnnotationFilterList-method}
+\alias{convertFilter,AnnotationFilterList,ANY-method}
 \alias{convertFilter}
 \alias{show,AnnotationFilterList-method}
 \title{Combining annotation filters}
@@ -29,7 +29,7 @@ AnnotationFilterList(..., logicOp = character(), logOp = character(),
 \S4method{distributeNegation}{AnnotationFilterList}(object,
   .prior_negation = FALSE)
 
-\S4method{convertFilter}{AnnotationFilterList}(object)
+\S4method{convertFilter}{AnnotationFilterList,ANY}(object)
 
 \S4method{show}{AnnotationFilterList}(object)
 }


### PR DESCRIPTION
Change the signature for `convertFilter` to `object` and `db`. Rationale:
In `ensembldb` I could implement e.g. a `convertFilter` for `object = "GenenameFilter", db = "EnsDb"` that *translates* the filter into an SQL call specific for the database layout of the `EnsDb` databases.

`convertFilter(GenenameFilter("BCL2"), db = edb)` would e.g. return `"gene_name = 'BCL2'". Internally I am already doing some similar stuff, implementing `convertFilter,AnnotationFilter,EnsDb` would expose this functionality to the user.

Open for discussion.